### PR TITLE
Fix: return early and propose no bump if tag matches YYYY.MM format

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -41830,6 +41830,9 @@ function main() {
             if (!recommendation || !lastTag) {
                 throw new Error('Unable to retrieve commits and tag information');
             }
+            if (lastTag.match(/^20\d\d\.\d\d/)) {
+                return;
+            }
 
             let lastVersion;
             let version;

--- a/index.js
+++ b/index.js
@@ -50,6 +50,10 @@ function main() {
             if (!recommendation || !lastTag) {
                 throw new Error('Unable to retrieve commits and tag information');
             }
+            if (lastTag.match(/^20\d\d\.\d\d/)) {
+                // YYYY.MM* tagging is not proper semver, and bump shouldn't be proposed
+                return;
+            }
 
             let lastVersion;
             let version;


### PR DESCRIPTION
Fix for the following comment appearing in PRs like [this one](https://github.com/oat-sa/tao-deliver-fe/pull/1244#issuecomment-2258310933).

![Screenshot 2024-07-30 at 15 09 55](https://github.com/user-attachments/assets/a0868f8f-4016-4715-ab88-2f598c733cbe)

When we use this monthly release tagging format, we don't want the action to propose a meaningless bump.